### PR TITLE
Enable setting of stream context options

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -42,7 +42,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 	private $persistent;
 
 	/** @var array */
-	private $context;
+	private $streamContext;
 
 
 	public function __construct(array $options = array())
@@ -61,7 +61,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 		if (!$this->port) {
 			$this->port = $this->secure === 'ssl' ? 465 : 25;
 		}
-		$this->context = isset($options['context']) ? $options['context'] : array();
+		$this->streamContext = isset($options['streamContext']) ? $options['streamContext'] : NULL;
 		$this->persistent = !empty($options['persistent']);
 	}
 
@@ -127,9 +127,8 @@ class SmtpMailer extends Nette\Object implements IMailer
 			throw new SmtpException($error, $errno);
 		}
 
-		// set context options
-		if ($this->context !== array()) {
-				stream_context_set_option($this->connection, $this->context);
+		if ($this->streamContext) {
+			stream_context_set_option($this->connection, $this->context);
 		}
 
 		stream_set_timeout($this->connection, $this->timeout, 0);

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -41,8 +41,8 @@ class SmtpMailer extends Nette\Object implements IMailer
 	/** @var bool */
 	private $persistent;
 
-    /** @var array */
-    private $context;
+	/** @var array */
+	private $context;
 
 
 	public function __construct(array $options = array())
@@ -61,7 +61,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 		if (!$this->port) {
 			$this->port = $this->secure === 'ssl' ? 465 : 25;
 		}
-        $this->context = isset($options['context']) ? $options['context'] : array();
+		$this->context = isset($options['context']) ? $options['context'] : array();
 		$this->persistent = !empty($options['persistent']);
 	}
 
@@ -127,10 +127,10 @@ class SmtpMailer extends Nette\Object implements IMailer
 			throw new SmtpException($error, $errno);
 		}
 
-        // set context options
-        if ($this->context !== array()) {
-            stream_context_set_option($this->connection, $this->context);
-        }
+		// set context options
+		if ($this->context !== array()) {
+				stream_context_set_option($this->connection, $this->context);
+		}
 
 		stream_set_timeout($this->connection, $this->timeout, 0);
 		$this->read(); // greeting

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -61,7 +61,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 		if (!$this->port) {
 			$this->port = $this->secure === 'ssl' ? 465 : 25;
 		}
-        $this->timeout = isset($options['context']) ? $options['context'] : array();
+        $this->context = isset($options['context']) ? $options['context'] : array();
 		$this->persistent = !empty($options['persistent']);
 	}
 

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -126,6 +126,12 @@ class SmtpMailer extends Nette\Object implements IMailer
 		if (!$this->connection) {
 			throw new SmtpException($error, $errno);
 		}
+
+        // set context options
+        if ($this->context !== array()) {
+            stream_context_set_option($this->connection, $this->context);
+        }
+
 		stream_set_timeout($this->connection, $this->timeout, 0);
 		$this->read(); // greeting
 

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -41,6 +41,9 @@ class SmtpMailer extends Nette\Object implements IMailer
 	/** @var bool */
 	private $persistent;
 
+    /** @var array */
+    private $context;
+
 
 	public function __construct(array $options = array())
 	{
@@ -58,6 +61,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 		if (!$this->port) {
 			$this->port = $this->secure === 'ssl' ? 465 : 25;
 		}
+        $this->timeout = isset($options['context']) ? $options['context'] : array();
 		$this->persistent = !empty($options['persistent']);
 	}
 


### PR DESCRIPTION
Some situations, namely mine, require to set some stream context options. This PR enables just that. User has to set an option array at initialization with an array that fits requirements of http://php.net/manual/en/function.stream-context-set-option.php