### PR TITLE
SmtpMailer: improved exception message on write failure

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -159,7 +159,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 
 
 	/**
-	 * Writes data to server and checks response.
+	 * Writes data to server and checks response against expected code if some provided.
 	 * @param  string
 	 * @param  int   response code
 	 * @param  string  error message
@@ -168,8 +168,11 @@ class SmtpMailer extends Nette\Object implements IMailer
 	protected function write($line, $expectedCode = NULL, $message = NULL)
 	{
 		fwrite($this->connection, $line . Message::EOL);
-		if ($expectedCode && !in_array((int) $this->read(), (array) $expectedCode, TRUE)) {
-			throw new SmtpException('SMTP server did not accept ' . ($message ? $message : $line));
+		if ($expectedCode) {
+			$response = $this->read();
+			if (!in_array((int) $response, (array) $expectedCode, TRUE)) {
+				throw new SmtpException('SMTP server did not accept ' . ($message ? $message : $line) . ' with error: ' . trim($response));
+			}
 		}
 	}
 


### PR DESCRIPTION
Previous behaviour was insufficient, you just got name of command which failed. There was no information why. Now you should see the response of SMTP server. For example:

```
SMTP server did not accept RCPT TO:<x@example.com> with error: 550 5.1.1 User unknown; rejecting
```
