### PR TITLE
Add getAttachments function

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -302,6 +302,16 @@ class Message extends MimePart
 
 
 	/**
+	 * Gets all email attachments.
+	 * @return MimePart[]
+	 */
+	public function getAttachments()
+	{
+		return $this->attachments;
+	}
+
+
+	/**
 	 * Creates file MIME part.
 	 * @return MimePart
 	 */


### PR DESCRIPTION
Add getAttachments function for getting all email attachments. It's useful if you use different way for email sending e.g. via Mailgun you are not able fill attachment parameter.

https://documentation.mailgun.com/api-sending.html#sending