### PR TITLE
Propagate links target from HTML message to plaintext version

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -399,6 +399,7 @@ class Message extends MimePart
 		$text = Strings::replace($html, [
 			'#<(style|script|head).*</\\1>#Uis' => '',
 			'#<t[dh][ >]#i' => ' $0',
+			'#<a [^>]*href=("|\')([^\\1]+)\\1[^>]*>(.*?)</a>#i' =>  '$3 &lt;$2&gt;',
 			'#[\r\n]+#' => ' ',
 			'#<(/?p|/?h\d|li|br|/tr)[ >/]#i' => "\n$0",
 		]);

--- a/tests/Mail/Mail.HtmlBodyAndLinks.phpt
+++ b/tests/Mail/Mail.HtmlBodyAndLinks.phpt
@@ -40,8 +40,8 @@ Content-Type: multipart/alternative;
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-Příliš žluťoučký
-kůň
+Příliš žluťoučký <http://green.example.com>
+kůň <http://horse.example.com>
 ----------%S%
 Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/tests/Mail/Mail.HtmlBodyAndLinks.phpt
+++ b/tests/Mail/Mail.HtmlBodyAndLinks.phpt
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Test: Nette\Mail\Message - HTML body.
+ */
+
+use Nette\Mail\Message;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Mail.inc';
+
+
+$mail = new Message();
+
+$mail->setFrom('John Doe <doe@example.com>');
+$mail->addTo('Lady Jane <jane@example.com>');
+$mail->setSubject('Hello Jane!');
+
+$mail->setHTMLBody('<b><span>Příliš </span> <a href="http://green.example.com">žluťoučký</a>' .
+		' <br><a href=\'http://horse.example.com\'>kůň</a></b>');
+
+$mailer = new TestMailer();
+$mailer->send($mail);
+
+Assert::match(<<<EOD
+MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+From: John Doe <doe@example.com>
+To: Lady Jane <jane@example.com>
+Subject: Hello Jane!
+Message-ID: <%S%@%S%>
+Content-Type: multipart/alternative;
+	boundary="--------%S%"
+
+----------%S%
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Příliš žluťoučký
+kůň
+----------%S%
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<b><span>Příliš </span> <a href="http://green.example.com">žluťoučký</a> <br><a href='http://horse.example.com'>kůň</a></b>
+----------%S%--
+EOD
+, TestMailer::$output);


### PR DESCRIPTION
Link in HTML mail may be important (like a links to verification, unsubscribe or other marketing behavior). Is important do not loss this information on all variants of e-mail message.

This PR add [textual citation](https://github.com/jakubboucek/mail/commit/6d989b68b8d7171381f3b797d9d08093bf1aafb8#diff-32e1e075c7628cedd7441bdadbe9da75L43) of link target.