### PR TITLE
Allow using a default stream context

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -114,9 +114,9 @@ class SmtpMailer extends Nette\Object implements IMailer
 	 */
 	protected function connect()
 	{
-		$this->connection = @fsockopen( // @ is escalated to exception
-			($this->secure === 'ssl' ? 'ssl://' : '') . $this->host,
-			$this->port, $errno, $error, $this->timeout
+		$this->connection = @stream_socket_client( // @ is escalated to exception
+			($this->secure === 'ssl' ? 'ssl://' : '') . $this->host . ':' . $this->port,
+			$errno, $error, $this->timeout
 		);
 		if (!$this->connection) {
 			throw new SmtpException($error, $errno);


### PR DESCRIPTION
Unfortunately, `fsockopen()` does not respect `stream_context_set_default()`. However, replacing it with `stream_socket_client()` resolves this. It will allow setting custom stream context options, without any substantial changes to `SmtpMailer`.

Of course, it would be nice if a stream context could be passed to the `SmtpMailer` (see #8), but until that's implemented, this will accomplish pretty much the same thing.