### PR TITLE
Adds DSN feature to SmtpMailer

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -39,6 +39,8 @@ class SmtpMailer extends Nette\Object implements IMailer
 	/** @var bool */
 	private $persistent;
 
+  /** @var dsn */
+	private $dsn;
 
 	public function __construct(array $options = [])
 	{
@@ -57,6 +59,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 			$this->port = $this->secure === 'ssl' ? 465 : 25;
 		}
 		$this->persistent = !empty($options['persistent']);
+    $this->dsn = isset($options['dsn']) ? $options['dsn'] : false;
 	}
 
 
@@ -85,7 +88,12 @@ class SmtpMailer extends Nette\Object implements IMailer
 				(array) $mail->getHeader('Cc'),
 				(array) $mail->getHeader('Bcc')
 			) as $email => $name) {
-				$this->write("RCPT TO:<$email>", [250, 251]);
+				if($this->dsn) {
+					$param = ' NOTIFY=success,delay,failure ORCPT=rfc822;'.$email;
+				} else {
+					$param = '';
+				}
+				$this->write("RCPT TO:<$email>$param", array(250, 251));
 			}
 
 			$mail->setHeader('Bcc', NULL);


### PR DESCRIPTION
This commit adds the possibility to set the notify flag in order to receive a delivery status notification from mail servers in order to be sure that an outgoing mail was successfully received by the target server. More details about the specs [here](http://www.sendmail.org/~ca/email/dsn.html). 
