### PR TITLE
Add defaultSender option

### DIFF
--- a/src/Bridges/MailDI/MailExtension.php
+++ b/src/Bridges/MailDI/MailExtension.php
@@ -24,6 +24,7 @@ class MailExtension extends Nette\DI\CompilerExtension
 		'password' => NULL,
 		'secure' => NULL,
 		'timeout' => NULL,
+		'defaultSender' => NULL,
 	];
 
 

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -39,6 +39,9 @@ class SmtpMailer extends Nette\Object implements IMailer
 	/** @var bool */
 	private $persistent;
 
+	/** @var string */
+	private $defaultSender;
+
 
 	public function __construct(array $options = [])
 	{
@@ -57,6 +60,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 			$this->port = $this->secure === 'ssl' ? 465 : 25;
 		}
 		$this->persistent = !empty($options['persistent']);
+		$this->defaultSender = isset($options['defaultSender']) ? $options['defaultSender'] : NULL;
 	}
 
 
@@ -74,8 +78,12 @@ class SmtpMailer extends Nette\Object implements IMailer
 				$this->connect();
 			}
 
+			if (!$mail->getHeader('From') && $this->defaultSender) {
+				$mail->setFrom($this->defaultSender);
+			}
+
 			if (($from = $mail->getHeader('Return-Path'))
-				|| ($from = key($mail->getHeader('From')))
+				|| (($fromHeader = $mail->getHeader('From')) && $from = key($fromHeader))
 			) {
 				$this->write("MAIL FROM:<$from>", 250);
 			}


### PR DESCRIPTION
`SendmailMailer` (default) works without setting `From` header, it uses the system one. When you switch your application to use `SmtpMailer`, it breaks if you don't specify the `From` header everywhere.

For ease of transitioning to `SmtpMailer`, it would be very beneficial to have an option for specifying a default sender.

Example:
```yaml
mail:
  smtp: yes
  host: smtp.example.com
  defaultSender: server@example.com
```


There are no tests for SmtpMailer at the moment, so it's not really easy to test this (without adding lots of code for the existing mailer).