### PR TITLE
Message: improved regexp for seaching embedded images

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -225,8 +225,8 @@ class Message extends MimePart
 			$matches = Strings::matchAll(
 				$html,
 				'#
-					(<img[^<>]*\s src\s*=\s*
-					|<body[^<>]*\s background\s*=\s*
+					(<(?:img|v:fill)[^<>]*\s src\s*=\s*
+					|<(?:body|table|td|th)[^<>]*\s background\s*=\s*
 					|<[^<>]+\s style\s*=\s* ["\'][^"\'>]+[:\s] url\(
 					|<style[^>]*>[^<]+ [:\s] url\()
 					(["\']?)(?![a-z]+:|[/\\#])([^"\'>)\s]+)

--- a/tests/Mail/Mail.textualAndHtmlBody.embedded.expect
+++ b/tests/Mail/Mail.textualAndHtmlBody.embedded.expect
@@ -22,7 +22,9 @@ Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: 7bit
 
 	<BODY id=1 background=cid:%S%>
+	<td background=cid:%S%>
 	<img src="cid:%S%">
+	<v:fill src="cid:%S%">
 	<div title=a style="background:url(cid:%S%)">
 	<style type=text/css>body { background: url('cid:%S%') } </style>
 

--- a/tests/Mail/Mail.textualAndHtmlBody.embedded.phpt
+++ b/tests/Mail/Mail.textualAndHtmlBody.embedded.phpt
@@ -23,7 +23,9 @@ $mail->setBody('Sample text');
 
 $mail->setHTMLBody('
 	<BODY id=1 background=background.png>
+	<td background=background.png>
 	<img src="backgroun%64.png">
+	<v:fill src="background.png">
 	<div title=a style="background:url(background.png)">
 	<style type=text/css>body { background: url(\'background.png\') } </style>
 ', __DIR__ . '/files');


### PR DESCRIPTION
This reduces the BC break caused by https://github.com/nette/mail/commit/e02911acc755d4e0dfacb0d97ee2306e3d8b5ef5.

There is another problem – only a single attribute of given element is processed, i.e. the following will not work. I did not find an easy way to solve this without processing the HTML multiple times.

~~~html
<td background=background.png style="background:url(background.png)">
~~~