### PR TITLE
Allow set stream context

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,12 +69,17 @@ Custom mailer
 Default mailer uses PHP function `mail`. If you need to send mail through a SMTP server, you can use `SmtpMailer`.
 
 ```php
-$mailer = new Nette\Mail\SmtpMailer(array(
+$mailer = new Nette\Mail\SmtpMailer([
         'host' => 'smtp.gmail.com',
         'username' => 'john@gmail.com',
         'password' => '*****',
         'secure' => 'ssl',
-));
+        'context' =>  [
+            'ssl' => [
+                'capath' => '/path/to/my/trusted/ca/folder',
+             ],
+        ],
+]);
 $mailer->send($mail);
 ```
 

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -38,6 +38,9 @@ class SmtpMailer implements IMailer
 	/** @var int */
 	private $timeout;
 
+	/** @var resource */
+	private $context;
+
 	/** @var bool */
 	private $persistent;
 
@@ -55,6 +58,7 @@ class SmtpMailer implements IMailer
 		$this->password = isset($options['password']) ? $options['password'] : '';
 		$this->secure = isset($options['secure']) ? $options['secure'] : '';
 		$this->timeout = isset($options['timeout']) ? (int) $options['timeout'] : 20;
+		$this->context = isset($options['context']) ? stream_context_create($options['context']) : stream_context_get_default();
 		if (!$this->port) {
 			$this->port = $this->secure === 'ssl' ? 465 : 25;
 		}
@@ -118,7 +122,7 @@ class SmtpMailer implements IMailer
 	{
 		$this->connection = @stream_socket_client( // @ is escalated to exception
 			($this->secure === 'ssl' ? 'ssl://' : '') . $this->host . ':' . $this->port,
-			$errno, $error, $this->timeout
+			$errno, $error, $this->timeout, STREAM_CLIENT_CONNECT, $this->context
 		);
 		if (!$this->connection) {
 			throw new SmtpException($error, $errno);


### PR DESCRIPTION
In current implementation, there is no way to modify stream context parameters.

Which means there is no way to connect (since [php 5.6](http://php.net/manual/en/migration56.openssl.php)) to SSL/TLS server with self-signed, expired, missmatched CN, etc..

See this problem on [forum](https://forum.nette.org/cs/25121-nette-mail-smtpmailer-na-port-587-certificate-verify-failed), for example.

If this is acceptable I would like to discuss possible approaches:
- allow set full stream context 
- allow set only some values (verify_peer, verify_peer_name, etc...)

Also there is problem how to catch warnings from underlying Openssl library and provide it to SmtpException as error message.

There is MR, more like experiment, implementation is vague.

We can find inspiration for example in [Ruby](https://github.com/mikel/mail/blob/master/lib/mail/network/delivery_methods/smtp.rb).