### PR TITLE
Able to set mail message default headers via settings by config

### DIFF
--- a/src/Bridges/MailDI/MailExtension.php
+++ b/src/Bridges/MailDI/MailExtension.php
@@ -5,6 +5,8 @@
  * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
  */
 
+declare(strict_types=1);
+
 namespace Nette\Bridges\MailDI;
 
 use Nette;

--- a/src/Bridges/MailDI/MailExtension.php
+++ b/src/Bridges/MailDI/MailExtension.php
@@ -25,7 +25,7 @@ class MailExtension extends Nette\DI\CompilerExtension
 		'secure' => NULL,
 		'timeout' => NULL,
 		'message' => [
-			"headers" => [],
+			"defaultHeaders" => [],
 		],
 	];
 
@@ -49,14 +49,19 @@ class MailExtension extends Nette\DI\CompilerExtension
 		}
 	}
 
+
 	public function afterCompile(Nette\PhpGenerator\ClassType $class)
 	{
 		$initialize = $class->getMethod('initialize');
 		$config = $this->validateConfig($this->defaults);
 
-		foreach ($config["message"]["headers"] as $name => $value) {
+		foreach ((array) $config["message"]["defaultHeaders"] as $name => $value) {
 			if ($value === FALSE) {
-				$initialize->addBody('unset(Nette\Mail\Message::$defaultHeaders[?]);', [$name]);
+				if (isset(Nette\Mail\Message::$defaultHeaders[$name])) {
+					$initialize->addBody('unset(Nette\Mail\Message::$defaultHeaders[?]);', [$name]);
+				} else {
+					throw new Nette\InvalidArgumentException('Default mail message header "' . $name . '" does not exist.');
+				}
 			} else {
 				$initialize->addBody('Nette\Mail\Message::$defaultHeaders[?] = ?;', [$name, $value]);
 			}

--- a/src/Bridges/MailDI/MailExtension.php
+++ b/src/Bridges/MailDI/MailExtension.php
@@ -26,6 +26,10 @@ class MailExtension extends Nette\DI\CompilerExtension
 		'password' => NULL,
 		'secure' => NULL,
 		'timeout' => NULL,
+		'message' => [
+			'mime-version' => NULL,
+			'x-mailer' => NULL,
+		],
 	];
 
 
@@ -41,6 +45,22 @@ class MailExtension extends Nette\DI\CompilerExtension
 			$mailer->setFactory(Nette\Mail\SendmailMailer::class);
 		} else {
 			$mailer->setFactory(Nette\Mail\SmtpMailer::class, [$config]);
+		}
+
+		if ($config['message']['mime-version'] === FALSE) {
+			unset(Nette\Mail\Message::$defaultHeaders['MIME-Version']);
+		} else {
+			if ($config['message']['mime-version'] !== NULL) {
+				Nette\Mail\Message::$defaultHeaders['MIME-Version'] = $config['message']['mime-version'];
+			}
+		}
+
+		if ($config['message']['x-mailer'] === FALSE) {
+			unset(Nette\Mail\Message::$defaultHeaders['X-Mailer']);
+		} else {
+			if ($config['message']['x-mailer'] !== NULL) {
+				Nette\Mail\Message::$defaultHeaders['X-Mailer'] = $config['message']['x-mailer'];
+			}
 		}
 
 		if ($this->name === 'mail') {

--- a/src/Bridges/MailDI/MailExtension.php
+++ b/src/Bridges/MailDI/MailExtension.php
@@ -27,7 +27,7 @@ class MailExtension extends Nette\DI\CompilerExtension
 		'secure' => NULL,
 		'timeout' => NULL,
 		'message' => [
-			"defaultHeaders" => [],
+			'defaultHeaders' => [],
 		],
 	];
 
@@ -57,7 +57,7 @@ class MailExtension extends Nette\DI\CompilerExtension
 		$initialize = $class->getMethod('initialize');
 		$config = $this->validateConfig($this->defaults);
 
-		foreach ((array) $config["message"]["defaultHeaders"] as $name => $value) {
+		foreach ((array) $config['message']['defaultHeaders'] as $name => $value) {
 			if ($value === FALSE) {
 				if (isset(Nette\Mail\Message::$defaultHeaders[$name])) {
 					$initialize->addBody('unset(Nette\Mail\Message::$defaultHeaders[?]);', [$name]);


### PR DESCRIPTION
- bug fix? **no**
- new feature? **yes**
- BC break? **no**

Easy way, how to set global mail message default headers. Look at the example below:

**config.neon**
```neon
mail:
	message:
		defaultHeaders:
			"header": "value"
			"X-Mailer": FALSE
			"BCC": "ales_wita@example.com" 