### PR TITLE
FallbackMailer: shuffle mailers with given probability

### DIFF
--- a/src/Mail/FallbackMailer.php
+++ b/src/Mail/FallbackMailer.php
@@ -31,10 +31,16 @@ class FallbackMailer implements IMailer
 
 	/**
 	 * @param IMailer[]
-	 * @param int $retryWaitTime in miliseconds
+	 * @param int
+	 * @param int   $retryWaitTime      in miliseconds
+	 * @param float $shuffleProbability probability that mailers will be shuffled
 	 */
-	public function __construct(array $mailers, int $retryCount = 3, int $retryWaitTime = 1000)
+	public function __construct(array $mailers, int $retryCount = 3, int $retryWaitTime = 1000, float $shuffleProbability = 0.0)
 	{
+		if ($shuffleProbability > 0.0 && mt_rand() / mt_getrandmax() < $shuffleProbability) {
+			shuffle($mailers);
+		}
+
 		$this->mailers = $mailers;
 		$this->retryCount = $retryCount;
 		$this->retryWaitTime = $retryWaitTime;

--- a/tests/Mail/FallbackMailer.phpt
+++ b/tests/Mail/FallbackMailer.phpt
@@ -84,3 +84,18 @@ test(function () {
 	$mailer->send(new Message);
 	Assert::null($onFailureCalls);
 });
+
+
+test(function () {
+	$subMailerA = new FailingMailer(0);
+	$subMailerB = new FailingMailer(1);
+
+	mt_srand(5);
+	$mailer = new FallbackMailer([$subMailerA, $subMailerB], 3, 10, 0.5);
+	$mailer->onFailure[] = function (FallbackMailer $sender, SendException $e, IMailer $mailer, Message $mail) use (&$onFailureCalls) {
+		$onFailureCalls[] = $mailer;
+	};
+
+	$mailer->send(new Message);
+	Assert::same([$subMailerB], $onFailureCalls);
+});


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: would be nice to have

Intended to periodically test the other mailers. 
I'm not sure whether default `$shuffleProbability` should be `0.0` or sth like `0.001` (would be a minor BC break).