### PR TITLE
setHtmlBody compatible http url

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -218,20 +218,32 @@ class Message extends MimePart
 
 		if ($basePath) {
 			$cids = [];
-			$matches = Strings::matchAll(
-				$html,
-				'#
+			if($basePath === true){
+                $match = '#
+					(<img[^<>]*\s src\s*=\s*
+					|<body[^<>]*\s background\s*=\s*
+					|<[^<>]+\s style\s*=\s* ["\'][^"\'>]+[:\s] url\(
+					|<style[^>]*>[^<]+ [:\s] url\()
+					(["\']?)([a-z]+:|[/\\#])([^"\'>)\s]+)
+					|\[\[ ([\w()+./@~-]+) \]\]
+				#ix';
+            }else{
+                $match = '#
 					(<img[^<>]*\s src\s*=\s*
 					|<body[^<>]*\s background\s*=\s*
 					|<[^<>]+\s style\s*=\s* ["\'][^"\'>]+[:\s] url\(
 					|<style[^>]*>[^<]+ [:\s] url\()
 					(["\']?)(?![a-z]+:|[/\\#])([^"\'>)\s]+)
 					|\[\[ ([\w()+./@~-]+) \]\]
-				#ix',
-				PREG_OFFSET_CAPTURE
-			);
+				#ix';
+            }
+			$matches = Strings::matchAll($html, $match, PREG_OFFSET_CAPTURE);
 			foreach (array_reverse($matches) as $m) {
-				$file = rtrim($basePath, '/\\') . '/' . (isset($m[4]) ? $m[4][0] : urldecode($m[3][0]));
+				if($basePath === true){
+                    $file = isset($m[4]) ? $m[3][0] . $m[4][0] : urldecode($m[3][0]);
+                }else{
+                    $file = rtrim($basePath, '/\\') . '/' . (isset($m[4]) ? $m[4][0] : urldecode($m[3][0]));
+                }
 				if (!isset($cids[$file])) {
 					$cids[$file] = substr($this->addEmbeddedFile($file)->getHeader('Content-ID'), 1, -1);
 				}


### PR DESCRIPTION
URL Settings in the email body image attachment, compatible form of HTTP path.Without limiting local path

- new feature? yes

**Use examples**

```php
        $message = new Nette\Mail\Message();
        $message->setFrom('John <john@example.com>');
        $message->addTo('username@gmail.com');
        $message->setSubject('test mail subject');
        $message->setHtmlBody('<p>mail body. <img src="https://img11.360buyimg.com/da/jfs/t5425/15/2370535202/189864/521bc763/591a7195N9b03ea5e.jpg" /></p>', true);
        $mailer = new Nette\Mail\SendmailMailer([
            'host' => 'smtp.gmail.com',
            'username' => 'john@gmail.com',
            'password' => '*****',
            'secure' => 'ssl',
        ]);
        $mailer->send($mail);
```
On the premise of not change the original function of modified, if you have any pictures in my email body when demand, automatic access to remote images.Correct me if there is a better way, thank you!

