### PR TITLE
added support for context param in config.neon

### DIFF
--- a/src/Bridges/MailDI/MailExtension.php
+++ b/src/Bridges/MailDI/MailExtension.php
@@ -26,6 +26,7 @@ class MailExtension extends Nette\DI\CompilerExtension
 		'password' => NULL,
 		'secure' => NULL,
 		'timeout' => NULL,
+		'context'  => NULL,
 	];
 
 


### PR DESCRIPTION
you can add param context for more specific configuration, eg.
mail:
	smtp: true
	...
	secure: ssl
	context:
		ssl:
			verify_peer: false
			verify_peer_name: false

- bug fix? no
- new feature? yes
- BC break? no
- doc PR: none

added support for context param in config.neon
