### PR TITLE
Message: hostname can be set in constructor, using only $_SERVER['HTT…

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -49,12 +49,27 @@ class Message extends MimePart
 			$this->setHeader($name, $value);
 		}
 		$this->setHeader('Date', date('r'));
+		$this->hostname = $hostname;
+	}
 
-		if ($hostname !== NULL) {
-			$this->hostname = $hostname;
-		} else {
-			$this->hostname = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : php_uname('n');
-		}
+
+	/**
+	 * @param string $hostname
+	 * @return static
+	 */
+	public function setHostname($hostname)
+	{
+		$this->hostname = $hostname;
+		return $this;
+	}
+
+
+	/**
+	 * @return string|NULL
+	 */
+	public function getHostname()
+	{
+		return $this->hostname;
 	}
 
 
@@ -438,8 +453,25 @@ class Message extends MimePart
 	private function getRandomId()
 	{
 		return '<' . Nette\Utils\Random::generate() . '@'
-			. preg_replace('#[^\w.-]+#', '', $this->hostname)
+			. preg_replace('#[^\w.-]+#', '', $this->detectHostname())
 			. '>';
+	}
+
+
+	/**
+	 * @return string
+	 */
+	private function detectHostname()
+	{
+		if ($this->hostname) {
+			return $this->hostname;
+		}
+
+		if ($from = $this->getFrom()) {
+			return explode('@', key($from))[1];
+		}
+
+		return isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : php_uname('n');
 	}
 
 }

--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -39,13 +39,22 @@ class Message extends MimePart
 	/** @var string */
 	private $htmlBody = '';
 
+	/** @var string */
+	private $hostname;
 
-	public function __construct()
+
+	public function __construct($hostname = NULL)
 	{
 		foreach (static::$defaultHeaders as $name => $value) {
 			$this->setHeader($name, $value);
 		}
 		$this->setHeader('Date', date('r'));
+
+		if ($hostname !== NULL) {
+			$this->hostname = $hostname;
+		} else {
+			$this->hostname = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : php_uname('n');
+		}
 	}
 
 
@@ -429,7 +438,7 @@ class Message extends MimePart
 	private function getRandomId()
 	{
 		return '<' . Nette\Utils\Random::generate() . '@'
-			. preg_replace('#[^\w.-]+#', '', isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : php_uname('n'))
+			. preg_replace('#[^\w.-]+#', '', $this->hostname)
 			. '>';
 	}
 

--- a/tests/Mail/Mail.hostname.phpt
+++ b/tests/Mail/Mail.hostname.phpt
@@ -52,3 +52,31 @@ Message-ID: <%S%@http.host>
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 7bit
 ', TestMailer::$output);
+
+$mail = new Message();
+$mail->setFrom('pepa@seznam.cz');
+$mailer->send($mail);
+
+Assert::match('MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+From: pepa@seznam.cz
+Message-ID: <%S%@seznam.cz>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+', TestMailer::$output);
+
+
+$mail = new Message;
+$mail->setHostname('nette.org');
+$mail->setFrom('pepa@seznam.cz');
+$mailer->send($mail);
+
+Assert::match('MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+From: pepa@seznam.cz
+Message-ID: <%S%@nette.org>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+', TestMailer::$output);

--- a/tests/Mail/Mail.hostname.phpt
+++ b/tests/Mail/Mail.hostname.phpt
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Test: Nette\Mail\Message hostname.
+ */
+
+use Nette\Mail\Message;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Mail.php';
+
+
+$mailer = new TestMailer();
+
+$mail = new Message('nette.org');
+$mailer->send($mail);
+
+Assert::match('MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+Message-ID: <%S%@nette.org>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+', TestMailer::$output);
+
+
+$hostname =  php_uname('n');
+
+$mail = new Message();
+$mailer->send($mail);
+
+Assert::match("MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+Message-ID: <%S%@$hostname>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+", TestMailer::$output);
+
+$_SERVER['HTTP_HOST'] = 'http.host';
+
+$mail = new Message();
+$mailer->send($mail);
+
+Assert::match('MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+Message-ID: <%S%@http.host>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+', TestMailer::$output);


### PR DESCRIPTION
…P_HOST'] is insufficient

Gmail pays particularly close attention to Message ID and Received headers. Message IDs that are formed incorrectly (without brackets <> and with wrong domain after @) can make Gmail think you are a spammer.
