### PR TITLE
SmtpSender: Better handling of exceptions thrown when building the message

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -74,7 +74,9 @@ class SmtpMailer implements IMailer
 	 */
 	public function send(Message $mail): void
 	{
-		$mail = clone $mail;
+		$tmp = clone $mail;
+		$tmp->setHeader('Bcc', null);
+		$data = $tmp->generateMessage();
 
 		try {
 			if (!$this->connection) {
@@ -95,8 +97,6 @@ class SmtpMailer implements IMailer
 				$this->write("RCPT TO:<$email>", [250, 251]);
 			}
 
-			$mail->setHeader('Bcc', null);
-			$data = $mail->generateMessage();
 			$this->write('DATA', 354);
 			$data = preg_replace('#^\.#m', '..', $data);
 			$this->write($data);


### PR DESCRIPTION
- bug fix? yes, #42 
- new feature? no
- BC break? no

Message contents are built before the communication with the SMTP server is started. In case an exception is thrown during message building, the connection is left in sane state. More in #42 