### PR TITLE
Remove @ error suppression when connecting.

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -130,7 +130,7 @@ class SmtpMailer implements IMailer
 	 */
 	protected function connect(): void
 	{
-		$this->connection = @stream_socket_client(// @ is escalated to exception
+		$this->connection = stream_socket_client(
 			($this->secure === 'ssl' ? 'ssl://' : '') . $this->host . ':' . $this->port,
 			$errno, $error, $this->timeout, STREAM_CLIENT_CONNECT, $this->context
 		);


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

With error suppression, i.e. `@stream_socket_client()`, will have `$errno` set to `0` and `$error` being an empty string `''`. This is an undocumented behaviour but leads to inconveniences during debug and development.

According to [the document](http://php.net/manual/en/function.stream-socket-client.php) and my tests with PHP 7.0, 7.1 and 7.2 this function does not throw.

Removing the `@` sign will have the function populates the actual `$errno` and `$error` which I believe is in fact the expected result.