### PR TITLE
Mail: added DKIM signer

### DIFF
--- a/src/Mail/DkimSigner.php
+++ b/src/Mail/DkimSigner.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2018 Lukáš Piják
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Mail;
+
+use Nette;
+
+
+class DkimSigner implements ISigner
+{
+	use Nette\SmartObject;
+
+	private const DEFAULT_SIGN_HEADERS = [
+		'From',
+		'To',
+		'Date',
+		'Subject',
+		'Message-ID',
+		'X-Mailer',
+		'Content-Type',
+	];
+
+	private const DKIM_SIGNATURE = 'DKIM-Signature';
+
+	/** @var string */
+	private $domain;
+
+	/** @var array */
+	private $signHeaders;
+
+	/** @var string */
+	private $selector;
+
+	/** @var string */
+	private $privateKey;
+
+	/** @var string */
+	private $passPhrase;
+
+	/** @var bool */
+	private $testMode = false;
+
+
+	/**
+	 * DkimSigner constructor.
+	 * @param array $settings
+	 * @param array $signHeaders
+	 * @throws SignException
+	 */
+	public function __construct(array $settings, array $signHeaders = self::DEFAULT_SIGN_HEADERS)
+	{
+		if (extension_loaded('openssl')) {
+			$this->domain = $settings['domain'] ?? '';
+			$this->selector = $settings['selector'] ?? '';
+			$this->privateKey = $settings['privateKey'] ?? '';
+			$this->passPhrase = $settings['passPhrase'] ?? '';
+			$this->testMode = isset($settings['testMode']) ? (bool) $settings['testMode'] : false;
+			$this->signHeaders = count($signHeaders) > 0 ? $signHeaders : self::DEFAULT_SIGN_HEADERS;
+		} else {
+			throw new SignException('OpenSSL not installed');
+		}
+	}
+
+
+	/**
+	 * @param Message $message
+	 * @return string
+	 * @throws SignException
+	 */
+	public function generateSignedMessage(Message $message): string
+	{
+		if (preg_match("~(.*?\r\n\r\n)(.*)~s", $message->generateMessage(), $parts)) {
+			[$_, $header, $body] = $parts;
+
+			return rtrim($header, "\r\n") . "\r\n" . $this->getSignature($message, $header, $this->normalizeNewLines($body)) . "\r\n\r\n" . $body;
+		}
+		throw new SignException('Malformed email');
+	}
+
+
+	/**
+	 * @param Message $message
+	 * @param string $header
+	 * @param string $body
+	 * @return string
+	 */
+	protected function getSignature(Message $message, string $header, string $body): string
+	{
+		$parts = [];
+
+		foreach (
+			[
+				'v' => '1',
+				'a' => 'rsa-sha256',
+				'q' => 'dns/txt',
+				'l' => strlen($body),
+				's' => $this->selector,
+				't' => $this->testMode ? 0 : time(),
+				//'x' => time() + 60,
+				'c' => 'relaxed/simple',
+				'h' => implode(':', $this->getSignedHeaders($message)),
+				'd' => $this->domain,
+				'bh' => $this->computeBodyHash($body),
+				'b' => '',
+			] as $key => $value) {
+			$parts[] = $key . '=' . $value;
+		}
+
+		return $this->computeSignature($header, self::DKIM_SIGNATURE . ': ' . implode('; ', $parts));
+	}
+
+
+	/**
+	 * @param string $rawHeader
+	 * @param string $signature
+	 * @return string
+	 */
+	protected function computeSignature(string $rawHeader, string $signature): string
+	{
+		$selectedHeaders = array_merge($this->signHeaders, [self::DKIM_SIGNATURE]);
+
+		$rawHeader = preg_replace("/\r\n[ \t]+/", ' ', rtrim($rawHeader, "\r\n") . "\r\n" . $signature);
+
+		$parts = [];
+		foreach ($test = explode("\r\n", $rawHeader) as $key => $header) {
+			if (strpos($header, ':') !== false) {
+				[$heading, $value] = explode(':', $header, 2);
+
+				if (($index = array_search($heading, $selectedHeaders, true)) !== false) {
+					$parts[$index] =
+						trim(strtolower($heading), " \t") . ':' .
+						trim(preg_replace("/[ \t]{2,}/", ' ', $value), " \t");
+				}
+			}
+		}
+
+		ksort($parts);
+
+		return $signature . $this->sign(implode("\r\n", $parts));
+	}
+
+
+	/**
+	 * @param string $value
+	 * @return string
+	 * @throws SignException
+	 */
+	protected function sign(string $value): string
+	{
+		$privateKey = openssl_pkey_get_private($this->privateKey, $this->passPhrase);
+
+		if ($privateKey) {
+			if (openssl_sign($value, $signature, $privateKey, 'sha256WithRSAEncryption')) {
+				openssl_pkey_free($privateKey);
+
+				return base64_encode($signature);
+			}
+			openssl_pkey_free($privateKey);
+		}
+		throw new SignException('Invalid private key');
+	}
+
+
+	/**
+	 * @param string $body
+	 * @return string
+	 */
+	protected function computeBodyHash(string $body): string
+	{
+		return base64_encode(
+			pack(
+				'H*',
+				hash('sha256', $body)
+			)
+		);
+	}
+
+
+	/**
+	 * @param string $string
+	 * @return string
+	 */
+	protected function normalizeNewLines(string $string): string
+	{
+		if (strlen($string) > 0) {
+			return rtrim(
+				str_replace("\r", "\r\n",
+					str_replace(["\r\n", "\n"], "\r", $string)
+				), "\r\n") . "\r\n";
+		}
+
+		return "\r\n";
+	}
+
+
+	/**
+	 * @param Message $message
+	 * @return array
+	 */
+	protected function getSignedHeaders(Message $message): array
+	{
+		return array_filter($this->signHeaders, function ($name) use ($message) {
+			return $message->getHeader($name) !== null;
+		});
+	}
+}

--- a/src/Mail/ISigner.php
+++ b/src/Mail/ISigner.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2018 Lukáš Piják (https://lukaspijak.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Mail;
+
+
+/**
+ * Signer interface.
+ */
+interface ISigner
+{
+
+	/**
+	 * @param Message $message
+	 * @return string
+	 * @throws SignException
+	 */
+	public function generateSignedMessage(Message $message): string;
+}

--- a/src/Mail/SendmailMailer.php
+++ b/src/Mail/SendmailMailer.php
@@ -22,6 +22,20 @@ class SendmailMailer implements IMailer
 	/** @var string|null */
 	public $commandArgs;
 
+	/** @var ISigner|null */
+	public $signer;
+
+
+	/**
+	 * @param ISigner $signer
+	 * @return self
+	 */
+	public function setSigner(ISigner $signer): self
+	{
+		$this->signer = $signer;
+		return $this;
+	}
+
 
 	/**
 	 * Sends email.
@@ -33,7 +47,13 @@ class SendmailMailer implements IMailer
 		$tmp->setHeader('Subject', null);
 		$tmp->setHeader('To', null);
 
-		$parts = explode(Message::EOL . Message::EOL, $tmp->generateMessage(), 2);
+		if ($this->signer instanceof ISigner) {
+			$data = $this->signer->generateSignedMessage($tmp);
+		} else {
+			$data = $tmp->generateMessage();
+		}
+
+		$parts = explode(Message::EOL . Message::EOL, $data, 2);
 
 		$args = [
 			str_replace(Message::EOL, PHP_EOL, $mail->getEncodedHeader('To')),

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -19,6 +19,9 @@ class SmtpMailer implements IMailer
 {
 	use Nette\SmartObject;
 
+	/** @var ISigner|null */
+	public $signer;
+
 	/** @var resource */
 	private $connection;
 
@@ -79,6 +82,17 @@ class SmtpMailer implements IMailer
 
 
 	/**
+	 * @param ISigner $signer
+	 * @return self
+	 */
+	public function setSigner(ISigner $signer): self
+	{
+		$this->signer = $signer;
+		return $this;
+	}
+
+
+	/**
 	 * Sends email.
 	 * @throws SmtpException
 	 */
@@ -86,7 +100,12 @@ class SmtpMailer implements IMailer
 	{
 		$tmp = clone $mail;
 		$tmp->setHeader('Bcc', null);
-		$data = $tmp->generateMessage();
+
+		if ($this->signer instanceof ISigner) {
+			$data = $this->signer->generateSignedMessage($tmp);
+		} else {
+			$data = $tmp->generateMessage();
+		}
 
 		try {
 			if (!$this->connection) {

--- a/src/Mail/exceptions.php
+++ b/src/Mail/exceptions.php
@@ -33,3 +33,8 @@ class FallbackMailerException extends SendException
 	/** @var SendException[] */
 	public $failures;
 }
+
+
+class SignException extends SendException
+{
+}

--- a/tests/Mail/Mail.dkim.headers.phpt
+++ b/tests/Mail/Mail.dkim.headers.phpt
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Test: Nette\Mail\DkimSigner headers filter.
+ */
+
+declare(strict_types=1);
+
+use Nette\Mail\DkimSigner;
+use Nette\Mail\Message;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+if (!extension_loaded('openssl')) {
+	Tester\Environment::skip('OpenSSL not installed');
+}
+
+$signer = new class ([], [
+	'From',
+	'To',
+	'Date',
+	'Subject',
+	'Message-ID',
+	'X-Mailer',
+	'Content-Type',
+]) extends DkimSigner {
+	public function getSignedHeaders(Message $message): array
+	{
+		return parent::getSignedHeaders($message);
+	}
+};
+
+$mail = new Message;
+$mail->setFrom('John Doe <doe@example.com>');
+$mail->addTo('Lady Jane <jane@example.com>');
+$mail->setSubject('Hello Jane!');
+$mail->setBody('Příliš žluťoučký kůň');
+
+Assert::equal([
+	0 => 'From',
+	1 => 'To',
+	2 => 'Date',
+	3 => 'Subject',
+	5 => 'X-Mailer',
+], $signer->getSignedHeaders($mail));

--- a/tests/Mail/Mail.dkim.invalidKey.phpt
+++ b/tests/Mail/Mail.dkim.invalidKey.phpt
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test: Nette\Mail\DkimSigner invalid private key.
+ */
+
+declare(strict_types=1);
+
+use Nette\Mail\DkimSigner;
+use Nette\Mail\Message;
+use Nette\Mail\SignException;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+if (!extension_loaded('openssl')) {
+	Tester\Environment::skip('OpenSSL not installed');
+}
+
+$signer = new DkimSigner([]);
+
+$mail = new Message;
+$mail->setFrom('John Doe <doe@example.com>');
+$mail->addTo('Lady Jane <jane@example.com>');
+$mail->setSubject('Hello Jane!');
+$mail->setBody('Příliš žluťoučký kůň');
+
+Assert::exception(function () use ($signer, $mail) {
+	$signer->generateSignedMessage($mail);
+}, SignException::class);

--- a/tests/Mail/Mail.dkim.process.phpt
+++ b/tests/Mail/Mail.dkim.process.phpt
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Test: Nette\Mail\DkimSigner check process.
+ */
+
+declare(strict_types=1);
+
+use Nette\Mail\DkimSigner;
+use Nette\Mail\Message;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+if (!extension_loaded('openssl')) {
+	Tester\Environment::skip('OpenSSL not installed');
+}
+
+$signer = new class ([], [
+	'From',
+	'To',
+	'Subject',
+	'X-Mailer',
+	'Content-Type',
+]) extends DkimSigner {
+	public function computeSignature(string $rawHeader, string $signature): string
+	{
+		$headers = parent::computeSignature($rawHeader, $signature);
+
+		Assert::match(
+			'DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; l=31; s=; t=%i%; c=relaxed/simple; h=From:To:Subject:X-Mailer; d=; bh=ajG6YIACaHQVmGzBb/7kmuYS2aRqla4IYr5sTMwVP7k=; b=',
+			$headers
+		);
+
+		return $headers;
+	}
+
+
+	public function sign(string $value): string
+	{
+		$headers = <<<'EOT'
+from:John Doe <doe@example.com>
+to:Lady Jane <jane@example.com>
+subject:Hello Jane!
+x-mailer:Nette Framework
+content-type:text/plain; charset=UTF-8
+dkim-signature:v=1; a=rsa-sha256; q=dns/txt; l=31; s=; t=%i%; c=relaxed/simple; h=From:To:Subject:X-Mailer; d=; bh=ajG6YIACaHQVmGzBb/7kmuYS2aRqla4IYr5sTMwVP7k=; b=
+EOT;
+
+		Assert::match($headers, $value);
+
+		return '';
+	}
+
+
+	public function computeBodyHash(string $body): string
+	{
+		return parent::computeBodyHash($body);
+	}
+
+
+	public function normalizeNewLines(string $string): string
+	{
+		return parent::normalizeNewLines($string);
+	}
+
+
+	public function getSignedHeaders(Message $message): array
+	{
+		return parent::getSignedHeaders($message);
+	}
+};
+
+$mail = new Message;
+$mail->setFrom('John Doe <doe@example.com>');
+$mail->addTo('Lady Jane <jane@example.com>');
+$mail->setSubject('Hello Jane!');
+$mail->setBody('Příliš žluťoučký kůň');
+
+$signer->generateSignedMessage($mail);
+
+
+/* ------- Compute body hash ------- */
+Assert::same(
+	'abFfM+PwY0xL0+O1BKLPEFMxG2LPt7VnNuT0ID67bPo=',
+	$signer->computeBodyHash('<b><span>Příliš </span> <a href="http://green.example.com">žluťoučký</a> "' . ' <br><a href=\'http://horse.example.com\'>kůň</a></b>')
+);
+
+Assert::same(
+	's2Jb3VCMpa9+zZIo1utaYU2hUO1CYARjhuvfZK53qaw=',
+	$signer->computeBodyHash('I L@ve Nette <3')
+);
+
+
+/* ------- Get signed headers ------- */
+Assert::same("hello\r\n Nette\r\nTracy\r\n   \r\n<3\r\n", $signer->normalizeNewLines("hello\n Nette\rTracy\r\n   \r<3"));

--- a/tests/Mail/Mail.dkim.sign.phpt
+++ b/tests/Mail/Mail.dkim.sign.phpt
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Test: Nette\Mail\DkimSigner sign.
+ */
+
+declare(strict_types=1);
+
+use Nette\Mail\DkimSigner;
+use Nette\Mail\Message;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+if (!extension_loaded('openssl')) {
+	Tester\Environment::skip('OpenSSL not installed');
+}
+
+$privateKey = <<<'EOT'
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQCxDQWcHZB2hO5GNSaj7CUVbCw+wkRBZ9xtNCHqrWwqaUozqWkw
+50XEe5gtnvjPix3zmOKJQVY15bYIrgRsnHsbMA2TUSZZyYgCpeypSq7Mvp79H1ZF
+dHlVRUbjzgLzOAko7Yg3F7vwMS2SWAwZxRttCkDmQyMO0tn2kRE5ZJhFTQIDAQAB
+AoGBAJ3mTyp782rAAwD6RgvLfwcsAgm2l8j9J8j8xYLWR7FLVbHdVMMYf1BMKdwF
++0CdgYjOwLpIWuqWg1IaYDe9FswcvAVLvFmbkmbt40oWD0v67SVxITXjjKmaA6yL
+TF0QqVp7Wo2Rppi4K0A5JaK9FnsbWygGwdtNmz518Pc5JngBAkEA1xEqnzjAXFB5
+4egCaKj3uGpVfGelUFvIlFrxoLSrvZ4NSp0XdrR/lzBB/TsMi/WkZpPeeQUTy+bq
+GcIdXYc9IQJBANK/kjfXtg3tK0dNW/9GXcZA2Nb40475rnCruXy8nhv+S8KkccdY
+IDnSvSs1ALy3X3Ew+aAGtIeWJAHttihvNq0CQQCTrQTwSd7ERLo8Zbxps0ROTC2g
+++Zm1G9Zd00dRZH75PBJgK7g4rYN0aQuRwKphCW8DeMghF0AkPHEeCcD1t4hAkBM
+75y8gCY5HU0AYbBlF9YiCwheKkZpWqMhBL/ZVq5Nv97+drQGtxhEo7dlb5sOSc8w
+7lUi42/CU8BfZ91pE3idAkB4CvSZyTfH5MTM+ta7oQGq/HGMCB+nIOdy6OZ28nGA
+FAXmcXdM0CjhOg4Xnf07+X5iKyXZQ17ErPJgh/L1Ih/O
+-----END RSA PRIVATE KEY-----
+EOT;
+
+$mail = new Message;
+$mail->setFrom('John Doe <doe@example.com>');
+$mail->addTo('Lady Jane <jane@example.com>');
+$mail->setSubject('Hello Jane!');
+$mail->setBody('Příliš žluťoučký kůň');
+
+$signer = new DkimSigner([
+	'privateKey' => $privateKey,
+	'domain' => 'nette.org',
+	'selector' => 'selector',
+	'testMode' => true,
+], ['From', 'To', 'Subject']);
+
+Assert::match(<<<'EOD'
+MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+From: John Doe <doe@example.com>
+To: Lady Jane <jane@example.com>
+Subject: Hello Jane!
+Message-ID: <%a%@%a%>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; l=31; s=selector; t=0; c=relaxed/simple; h=From:To:Subject; d=nette.org; bh=ajG6YIACaHQVmGzBb/7kmuYS2aRqla4IYr5sTMwVP7k=; b=l/nd5fGVXwzPZNZFJrn3f7kvFmaFV5cybkBUYzvIoc6hDPNw6750KpBtwsdjvJQ8u7YaEo9kSm7v2CBQj6KVSafGUZ4hDr8Yv18TjOzO9j7iUjdVJulpYq77vNzinQo3cwpSdijbZEBOd+CJwsRyk+OtMG17Yz7sNa8+Xd2Lp+Q=
+
+Příliš žluťoučký kůň
+EOD
+	, $signer->generateSignedMessage($mail));


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no

Hello,

this is the implementation of DKIM signatures into emails, see https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail

In Nette is problematic to implement this feature, so I'd like to help it.

```php
$sender = new Nette\Mail\SendmailMailer();

$sender->setSigner(new Nette\Mail\DkimSigner([
	'domain' => 'nette.org',
	'selector' => 'key1',
	'privateKey' => '__PRIVATE_KEY__',
], [
    'To', 'From', 'Subject', 'Date'
]));

$sender->send(new Nette\Mail\Message());
```