### PR TITLE
Embedding SVG Images in Apple Mail

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -304,7 +304,10 @@ class Message extends MimePart
 		if (!strcasecmp($contentType, 'message/rfc822')) { // not allowed for attached files
 			$contentType = 'application/octet-stream';
 		}
-
+		if (!strcasecmp($contentType, 'image/svg')) { // Troublesome for some mailers...
+			$contentType = 'image/svg+xml';
+		}
+		
 		$part->setBody($content);
 		$part->setContentType($contentType);
 		$part->setEncoding(preg_match('#(multipart|message)/#A', $contentType) ? self::ENCODING_8BIT : self::ENCODING_BASE64);


### PR DESCRIPTION
Apple Mail for example has a problem displaying svg images with the content-type **image/svg**. It musst be called **image/svg+xml**. Correcting this here. Should not be a problem for other mailers.

- bug fix
- BC break? no


