### PR TITLE
Extension: Persistent parameter should be configurable

### DIFF
--- a/src/Bridges/MailDI/MailExtension.php
+++ b/src/Bridges/MailDI/MailExtension.php
@@ -27,6 +27,7 @@ class MailExtension extends Nette\DI\CompilerExtension
 		'timeout' => null,
 		'context' => null,
 		'clientHost' => null,
+		'persistent' => false,
 	];
 
 


### PR DESCRIPTION
- BC break? no

In my personal opinion is a persistent connection very useful, but if I want use it i must create my own extension to create an instance of SmtpMailer with a persistent connection, because default configuration does not support it.