### PR TITLE
Support for TLS 1.2 SMTP

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -150,9 +150,9 @@ class SmtpMailer implements IMailer
 		if ($this->secure === 'tls') {
 			$this->write('STARTTLS', 220);
 
-            $cryptoMethod = STREAM_CRYPTO_METHOD_TLS_CLIENT;
-            $cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
-            $cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+			$cryptoMethod = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+			$cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+			$cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
 
 			if (!stream_socket_enable_crypto($this->connection, true, $cryptoMethod)) {
 				throw new SmtpException('Unable to connect via TLS.');

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -149,7 +149,12 @@ class SmtpMailer implements IMailer
 
 		if ($this->secure === 'tls') {
 			$this->write('STARTTLS', 220);
-			if (!stream_socket_enable_crypto($this->connection, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
+
+            $cryptoMethod = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+            $cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+            $cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+
+			if (!stream_socket_enable_crypto($this->connection, true, $cryptoMethod)) {
 				throw new SmtpException('Unable to connect via TLS.');
 			}
 			$this->write("EHLO $this->clientHost", 250);


### PR DESCRIPTION
Version: 2.4

### Bug Description
If SMTP server support only TLS 1.2 isn't possible connect it. 

### Expected Behavior

In SmtpMailer is now this:
`stream_socket_enable_crypto($this->connection, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)`

i found solution on php.net

`$cryptoMethod = STREAM_CRYPTO_METHOD_TLS_CLIENT;`

`if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {`
`    $cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;`
`   $cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;`
`}`
			
`if (!stream_socket_enable_crypto($this->connection, true, $cryptoMethod)) {`
`    throw new SmtpException('Unable to connect via TLS.');`
`}`

What do you think?
