### PR TITLE
getFrom() can be null (in @mail() function)

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -66,9 +66,15 @@ class Message extends MimePart
 	/**
 	 * Returns the sender of the message.
 	 */
-	public function getFrom(): array
+	public function getFrom(): ?array
 	{
-		return $this->getHeader('From');
+		$from = $this->getHeader('From');
+
+		if ($from === null) {
+			trigger_error('Possible problem: Sender (header from) is empty.', E_USER_WARNING);
+		}
+
+		return $from;
 	}
 
 


### PR DESCRIPTION
- bug fix
- BC break? yes (fixing BC)

In past version of `Message` method `getFrom()` can return `null` value and SMTP server used default configuration.

If header `from` is null, now throw `E_USER_WARNING`.

Now Message return:

![Snímek obrazovky 2019-05-10 v 9 55 16](https://user-images.githubusercontent.com/4738758/57512024-dc09ae80-730a-11e9-8079-e82fabefc92b.png)
