### PR TITLE
SmtpMailer: Fix for servers which sends 250-AUTH only through encrypted connections

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -154,7 +154,7 @@ class SmtpMailer implements Mailer
 		}
 		stream_set_timeout($this->connection, $this->timeout, 0);
 		$this->read(); // greeting
-		
+
 		if ($this->secure === 'tls') {
 			$this->write('STARTTLS', 220);
 			if (!stream_socket_enable_crypto(

--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -154,13 +154,7 @@ class SmtpMailer implements Mailer
 		}
 		stream_set_timeout($this->connection, $this->timeout, 0);
 		$this->read(); // greeting
-
-		$this->write("EHLO $this->clientHost");
-		$ehloResponse = $this->read();
-		if ((int) $ehloResponse !== 250) {
-			$this->write("HELO $this->clientHost", 250);
-		}
-
+		
 		if ($this->secure === 'tls') {
 			$this->write('STARTTLS', 220);
 			if (!stream_socket_enable_crypto(
@@ -171,6 +165,12 @@ class SmtpMailer implements Mailer
 				throw new SmtpException('Unable to connect via TLS.');
 			}
 			$this->write("EHLO $this->clientHost", 250);
+		}
+
+		$this->write("EHLO $this->clientHost");
+		$ehloResponse = $this->read();
+		if ((int) $ehloResponse !== 250) {
+			$this->write("HELO $this->clientHost", 250);
 		}
 
 		if ($this->username != null && $this->password != null) {


### PR DESCRIPTION
- BC break? no

- There are some SMTP TLS  servers, which does not send 250-AUTH PLAIN  through non-tls channel, so, it was not possible to connect to server with Nette SMTP mailer and plain auth mechanism
- this commit fix this case by securing channel before EHLO