### PR TITLE
Message: use FileSystem::read() instead of native file_get_contents()

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -297,10 +297,7 @@ class Message extends MimePart
 	{
 		$part = new MimePart;
 		if ($content === null) {
-			$content = @file_get_contents($file); // @ is escalated to exception
-			if ($content === false) {
-				throw new Nette\FileNotFoundException("Unable to read file '$file'.");
-			}
+			$content = Nette\Utils\FileSystem::read($file);
 		}
 		if (!$contentType) {
 			$contentType = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $content);


### PR DESCRIPTION
- new feature
- BC break? no

I think `Nette\Utils\FileSystem::read` is more better than native `file_get_contents()` for safe reading file.
