### PR TITLE
SmtpMailer: From can be null

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -115,7 +115,7 @@ class SmtpMailer implements Mailer
 
 			if (
 				($from = $mail->getHeader('Return-Path'))
-				|| ($from = array_keys((array) $mail->getHeader('From'))[0])
+				|| ($from = array_keys((array) $mail->getHeader('From'))[0] ?? null)
 			) {
 				$this->write("MAIL FROM:<$from>", 250);
 			}


### PR DESCRIPTION
- bug fix
- BC break? no

Occasionally, when sending an email from Tracy, the "from" value may not exist:

![Snímek obrazovky 2020-11-29 v 16 49 13](https://user-images.githubusercontent.com/4738758/100546661-d19f6480-3262-11eb-88fe-346614ac2d1c.png)
