### PR TITLE
Message: preserves custom Message-ID

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -342,7 +342,11 @@ class Message extends MimePart
 	public function build()
 	{
 		$mail = clone $this;
-		$mail->setHeader('Message-ID', $this->getRandomId());
+
+		$messageIdHeaderName = 'Message-ID';
+		if ($mail->getHeader($messageIdHeaderName) === null) {
+			$mail->setHeader($messageIdHeaderName, $this->getRandomId());
+		}
 
 		$cursor = $mail;
 		if ($mail->attachments) {

--- a/tests/Mail/Mail.headers.messageId.phpt
+++ b/tests/Mail/Mail.headers.messageId.phpt
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Test: Nette\Mail\Message valid email addresses.
+ */
+
+declare(strict_types=1);
+
+use Nette\Mail\Message;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Mail.php';
+
+
+$mail = new Message;
+
+$mail->addTo('john.doe@example.com');
+
+$mailer = new TestMailer;
+$mailer->send($mail);
+
+Assert::match(<<<'EOD'
+MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+To: john.doe@example.com
+Message-ID: <%a%@%a%>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+EOD
+, TestMailer::$output);
+
+
+$mail->setHeader('Message-ID', 'xxx.yyy.zzz@example.com');
+
+$mailer->send($mail);
+
+echo TestMailer::$output;
+
+Assert::match(<<<'EOD'
+MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+To: john.doe@example.com
+Message-ID: xxx.yyy.zzz@example.com
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+EOD
+	, TestMailer::$output);

--- a/tests/Mail/Mail.headers.messageId.phpt
+++ b/tests/Mail/Mail.headers.messageId.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Nette\Mail\Message valid email addresses.
+ * Test: Nette\Mail\Message custom Message-ID header.
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
- new feature
- BC break? no

This PR is adding support for custom `Message-ID` header value.
