### PR TITLE
SendmailMailer: use CRLF endings for php >= 8.0

### DIFF
--- a/src/Mail/SendmailMailer.php
+++ b/src/Mail/SendmailMailer.php
@@ -53,7 +53,7 @@ class SendmailMailer implements Mailer
 			str_replace(Message::EOL, PHP_EOL, (string) $mail->getEncodedHeader('To')),
 			str_replace(Message::EOL, PHP_EOL, (string) $mail->getEncodedHeader('Subject')),
 			str_replace(Message::EOL, PHP_EOL, $parts[1]),
-			str_replace(Message::EOL, PHP_EOL, $parts[0]),
+			str_replace(Message::EOL, PHP_VERSION_ID >= 80000 ? "\r\n" : PHP_EOL, $parts[0]),
 		];
 
 		if ($from = $mail->getFrom()) {


### PR DESCRIPTION
Version: PHP 8.
OS: Not Windows! Must be one where `PHP_EOL` is not set to `\r\n`. 

### Bug Description
Since this update in PHP8 https://git.php.net/?p=php-src.git;a=commit;h=6983ae751cd301886c966b84367fc7aaa1273b2d which addressed bug https://bugs.php.net/bug.php?id=47983 mail headers must be separated by CRLF. Without CRLF the headers are separated by space.

### Steps To Reproduce
Run the following code:

```
<?php

require __DIR__ . '/../vendor/autoload.php';

$mail = new Nette\Mail\Message;
$mail->setFrom('GLAMI <info@glami.cz>')
    ->addTo('customer@email.cz')
    ->setSubject('Order Confirmation')
    ->setBody("Hello, Your order has been accepted.");

$mail->setHtmlBody('<p>Hello,</p><p>Your order has been accepted.</p>');

$mailer = new Nette\Mail\SendmailMailer;
$res = $mailer->send($mail);
```

### Expected Behavior
An HTML-formatted email.

```
Hello,

Your order has been accepted.
```

### Actual result
The email is missing the header and is treated as plaintext. The boundaries and the encoded mime-part contents show up in the message:

```
----------afprpktz9g
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 7bit

Hello, Your order has been accepted.
----------afprpktz9g
Content-Type: text/html; charset=UTF-8
Content-Transfer-Encoding: 7bit

<p>Hello,</p><p>Your order has been accepted.</p>
----------afprpktz9g--

```

TBH there's no test as I'm not able to create a simple test case for sending and receiving email.