### PR TITLE
Message::getPriority return type fix

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -189,7 +189,8 @@ class Message extends MimePart
 	 */
 	public function getPriority(): ?int
 	{
-		return $this->getHeader('X-Priority');
+		$priority = $this->getHeader('X-Priority');
+		return is_numeric($priority) ? (int) $priority : null;
 	}
 
 

--- a/tests/Mail/Mail.priority.phpt
+++ b/tests/Mail/Mail.priority.phpt
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Test: Nette\Mail\Message - Priority.
+ */
+
+declare(strict_types=1);
+
+use Nette\Mail\Message;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$mail = new Message;
+
+$mail->setPriority(2);
+
+Assert::same(2, $mail->getPriority());

--- a/tests/Mail/Mail.priority.phpt
+++ b/tests/Mail/Mail.priority.phpt
@@ -15,6 +15,8 @@ require __DIR__ . '/../bootstrap.php';
 
 $mail = new Message;
 
+Assert::null($mail->getPriority());
+
 $mail->setPriority(2);
 
 Assert::same(2, $mail->getPriority());


### PR DESCRIPTION
- bug fix  #86 
- BC break? no

Fixes a return type error in the `getPriority()` method.

close #86 