### PR TITLE
Bcc-only set To: undisclosed-recipients

### DIFF
--- a/src/Mail/SmtpMailer.php
+++ b/src/Mail/SmtpMailer.php
@@ -73,6 +73,10 @@ class SmtpMailer implements Mailer
 	{
 		$tmp = clone $mail;
 		$tmp->setHeader('Bcc', null);
+		if (!$tmp->getHeader('To') && !$tmp->getHeader('Cc')) {
+			// missing recipient headers make some mailers (e.g., sendmail) nervous -> set 'To' like many MTAs do
+			$tmp->setHeader('To', 'undisclosed-recipients: ;');
+		}
 
 		$data = $this->signer
 			? $this->signer->generateSignedMessage($tmp)

--- a/tests/Mail/Mail.SmtpMailer.bcc.phpt
+++ b/tests/Mail/Mail.SmtpMailer.bcc.phpt
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Test: Nette\Mail\SmtpMailer correctly handles Bcc-only message
+ */
+
+declare(strict_types=1);
+
+use Nette\Mail\Message;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/SmtpMailerTestWrapper.php';
+
+
+$mail = new Message;
+$mail->setFrom('Tester <tester@example.com>');
+$mail->addBcc('hidden1@example.com');
+$mail->addBcc('hidden2@example.com');
+
+$mailer = new SmtpMailerTestWrapper;
+$mailer->send($mail);
+
+// check the mail was sent to all Bcc mails
+list($from, $to1, $to2, $data, $body) = $mailer->getWrittenLines();
+Assert::equal("MAIL FROM:<tester@example.com>", $from);
+Assert::equal("RCPT TO:<hidden1@example.com>", $to1);
+Assert::equal("RCPT TO:<hidden2@example.com>", $to2);
+Assert::equal("DATA", $data);
+
+// make sure no Bcc is in the body and 'To; was set to 'undisclosed-recipients'
+$body = explode("\r\n", $body);
+$recipientHeaders = array_values(array_filter($body, function ($line) {
+	return preg_match('/^(To|Cc|Bcc):/i', $line);
+}));
+Assert::count(1, $recipientHeaders);
+Assert::equal("To: undisclosed-recipients: ;", $recipientHeaders[0]);

--- a/tests/Mail/SmtpMailerTestWrapper.php
+++ b/tests/Mail/SmtpMailerTestWrapper.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Common code for Mail test cases.
+ */
+
+declare(strict_types=1);
+
+use Nette\Mail\SmtpMailer;
+use Nette\Mail\Message;
+
+/**
+ * A wrapper for SmtpMailer (derived class) that helps with tesing.
+ * It overrides internal connection functions so we can mock TCP communication.
+ * Note: this is the first implementation -- it only collects the write operations.
+ */
+class SmtpMailerTestWrapper extends SmtpMailer
+{
+	private $connected = false;
+	private $written = [];
+
+	public function __construct() {
+		parent::__construct('localhost', '', '');
+	}
+
+	/**
+	 * Overrides connection to mock TCP interaction.
+	 */
+	protected function connect(): void
+	{
+		if ($this->connected) {
+			throw new Exception("The connect() function called, but the connection was already established.");
+		}
+		$this->connected = true;
+	}
+
+
+	/**
+	 * Terminates mocking connection.
+	 */
+	protected function disconnect(): void
+	{
+		if (!$this->connected) {
+			throw new Exception("The disconnect() function called, but no connection was currently established.");
+		}
+		$this->connected = false;
+	}
+
+
+	/**
+	 * Overrides writing function so we can collect, what was actually written by the sender.
+	 */
+	protected function write(string $line, int|array|null $expectedCode = null, ?string $message = null): void
+	{
+		$this->written[] = $line;
+	}
+
+
+	/**
+	 * Overrides reading function to mock inputs for the mailer.
+	 */
+	protected function read(): string
+	{
+		return ''; // not needed yet, may be implemented in the future
+	}
+
+	/**
+	 * Return lines collected in write calls.
+	 * @return string[]
+	 */
+	public function getWrittenLines(): array
+	{
+		return $this->written;
+	}
+}


### PR DESCRIPTION
New feature: When a mail is sent via SMTP mailer with only Bcc recipients, add 'To: undisclosed-recipients' header.
