### PR TITLE
Update SendmailMailer.php - setting envelope addres can be disabled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Images can also be extremely easily inserted into the HTML body of an email. Jus
 // automatically adds /path/to/images/background.gif to the email
 $mail->setHtmlBody(
 	'<b>Hello</b> <img src="background.gif">',
-	'/path/to/images'
+	'/path/to/images',
 );
 ```
 
@@ -118,14 +118,14 @@ $mail = new Nette\Mail\Message;
 $mail->setFrom('John <john@example.com>')
 	->addTo('jack@example.com')
 	->setHtmlBody(
-		$latte->renderToString('email.latte', $params),
-		'/path/to/images'
+		$latte->renderToString('/path/to/email.latte', $params),
+		'/path/to/images',
 	);
 ```
 
 File `email.latte`:
 
-```html
+```latte
 <html>
 <head>
 	<meta charset="utf-8">
@@ -174,22 +174,22 @@ SmtpMailer
 To send mail via the SMTP server, use `SmtpMailer`.
 
 ```php
-$mailer = new Nette\Mail\SmtpMailer([
-	'host' => 'smtp.gmail.com',
-	'username' => 'franta@gmail.com',
-	'password' => '*****',
-	'secure' => 'ssl',
-]);
+$mailer = new Nette\Mail\SmtpMailer(
+	host: 'smtp.gmail.com',
+	username: 'franta@gmail.com',
+	password: '*****',
+	encryption: Nette\Mail\SmtpMailer::EncryptionSSL,
+);
 $mailer->send($mail);
 ```
 
-If you do not specify `host`, the value from php.ini will be used. The following additional keys can be used in the options:
+The following additional parameters can be passed to the constructor:
 
 * `port` - if not set, the default 25 or 465 for `ssl` will be used
-* `context` - allows you to set [SSL context options](https://www.php.net/manual/en/context.ssl.php) for connection
 * `timeout` - timeout for SMTP connection
 * `persistent` - use persistent connection
 * `clientHost` - client designation
+* `streamOptions` - allows you to set [SSL context options](https://www.php.net/manual/en/context.ssl.php) for connection
 
 
 FallbackMailer
@@ -201,12 +201,12 @@ It does not send email but sends them through a set of mailers. If one mailer fa
 $mailer = new Nette\Mail\FallbackMailer([
 	$smtpMailer,
 	$backupSmtpMailer,
-	$sendmailMailer
+	$sendmailMailer,
 ]);
 $mailer->send($mail);
 ```
 
-Other parameters in the constructor include the number of repeat and waiting time in miliseconds.
+Other parameters in the constructor include the number of repeat and waiting time in milliseconds.
 
 
 DKIM
@@ -216,14 +216,14 @@ DKIM (DomainKeys Identified Mail) is a trustworthy email technology that also he
 The recipient's server compares this signature with the public key stored in the domain's DNS records. By matching the signature, it is shown that the email actually originated from the sender's domain and that the message was not modified during the transmission of the message.
 
 ```php
-$options = [
-	'domain' => 'nette.org',
-	'selector' => 'dkim',
-	'privateKey' => file_get_contents('../dkim/dkim.key'),
-	'passPhrase' => '****',
-];
+$signer = new Nette\Mail\DkimSigner(
+	domain: 'nette.org',
+	selector: 'dkim',
+	privateKey: file_get_contents('../dkim/dkim.key'),
+	passPhrase: '****',
+);
 
 $mailer = new Nette\Mail\SendmailMailer; // or SmtpMailer
-$mailer->setSigner(new Nette\Mail\DkimSigner($options));
+$mailer->setSigner($signer);
 $mailer->send($mail);
 ```

--- a/src/Bridges/MailDI/MailExtension.php
+++ b/src/Bridges/MailDI/MailExtension.php
@@ -45,7 +45,7 @@ class MailExtension extends Nette\DI\CompilerExtension
 	}
 
 
-	public function loadConfiguration()
+	public function loadConfiguration(): void
 	{
 		$builder = $this->getContainerBuilder();
 

--- a/src/Mail/SendmailMailer.php
+++ b/src/Mail/SendmailMailer.php
@@ -19,11 +19,22 @@ class SendmailMailer implements Mailer
 {
 	public string $commandArgs = '';
 	private ?Signer $signer = null;
+	// Setting an envelope address using command arg (-f $from) is allowed by default
+	private bool envelopeFrom = true;
 
 
 	public function setSigner(Signer $signer): static
 	{
 		$this->signer = $signer;
+		return $this;
+	}
+
+	/**
+	 * Enable/disable setting an envelope address using command arg (-f $from) 
+	 */
+	public function setEnvelopeFrom(bool $envelopeFrom): static
+	{
+		$this->evelopeFrom = $envelopeFrom;
 		return $this;
 	}
 
@@ -48,7 +59,7 @@ class SendmailMailer implements Mailer
 		$parts = explode(Message::EOL . Message::EOL, $data, 2);
 
 		$cmd = $this->commandArgs;
-		if ($from = $mail->getFrom()) {
+		if (($this->evelopeFrom) && ($from = $mail->getFrom())) {
 			$cmd .= ' -f' . key($from);
 		}
 


### PR DESCRIPTION
Setting envelope addres can be disiabled using:
'SendmailMailer->setEnvelopeFrom(false);'

- new feature 
- see more #96 