### PR TITLE
MimePart: fixed not escaped header before encoded into utf-8

### DIFF
--- a/src/Mail/MimePart.php
+++ b/src/Mail/MimePart.php
@@ -279,12 +279,21 @@ class MimePart
 	 */
 	private static function encodeSequence(string $s, int &$offset = 0, ?int $type = null): string
 	{
+		$escape = static function (string $s): string {
+			// RFC 2822 atext except =
+			if (preg_match('#[^ a-zA-Z0-9!\#$%&\'*+/?^_`{|}~-]#', $s) === 1) {
+				return sprintf('"%s"', addcslashes($s, '"\\'));
+			}
+
+			return $s;
+		};
+
 		if (
 			(strlen($s) < self::LineLength - 3) && // 3 is tab + quotes
 			strspn($s, "!\"#$%&\\'()*+,-./0123456789:;<>@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^`abcdefghijklmnopqrstuvwxyz{|}~=? _\r\n\t") === strlen($s)
 		) {
-			if ($type && preg_match('#[^ a-zA-Z0-9!\#$%&\'*+/?^_`{|}~-]#', $s)) { // RFC 2822 atext except =
-				return self::append('"' . addcslashes($s, '"\\') . '"', $offset);
+			if ($type !== null) {
+				$s = $escape($s);
 			}
 
 			return self::append($s, $offset);
@@ -294,6 +303,10 @@ class MimePart
 		if ($offset >= 55) { // maximum for iconv_mime_encode
 			$o = self::EOL . "\t";
 			$offset = 1;
+		}
+
+		if ($type !== null) {
+			$s = $escape($s);
 		}
 
 		$s = iconv_mime_encode(str_repeat(' ', $old = $offset), $s, [

--- a/tests/Mail/Mail.headers.002.phpt
+++ b/tests/Mail/Mail.headers.002.phpt
@@ -17,7 +17,7 @@ require __DIR__ . '/Mail.php';
 
 $mail = new Message;
 
-$mail->setFrom('John Doe <doe@example.com>');
+$mail->setFrom('Kdo uteče, obědvá <doe@example.com>');
 
 $mail->addTo('Lady Jane <jane@example.com>');
 $mail->addCc('jane@example.info');
@@ -37,7 +37,7 @@ Assert::match(<<<'EOD'
 	MIME-Version: 1.0
 	X-Mailer: Nette Framework
 	Date: %a%
-	From: John Doe <doe@example.com>
+	From: =?UTF-8?B?IktkbyB1dGXEjWUsIG9ixJtkdsOhIg==?= <doe@example.com>
 	To: Lady Jane <jane@example.com>
 	Cc: jane@example.info
 	Bcc: bcc@example.com
@@ -50,3 +50,5 @@ Assert::match(<<<'EOD'
 	Content-Type: text/plain; charset=UTF-8
 	Content-Transfer-Encoding: 7bit
 	EOD, TestMailer::$output);
+
+Assert::match('"Kdo uteče, obědvá"', iconv_mime_decode('=?UTF-8?B?IktkbyB1dGXEjWUsIG9ixJtkdsOhIg==?='));


### PR DESCRIPTION
- bug fix
- BC break? no

Headers containing special characters such as Czech characters also need to be escaped before converting to utf-8.

Example header `From: Kdo uteče, obědvá <doe@example.com>` 

When google processes the email, it misparses the comma and because of that the DKIM signature verification fails and the email is rejected.
