### PR TITLE
Support absolute paths in setHTMLBody for automatic CID embedding

### DIFF
--- a/src/Mail/Message.php
+++ b/src/Mail/Message.php
@@ -207,13 +207,13 @@ class Message extends MimePart
 					|<body[^<>]*\s background\s*=\s*
 					|<[^<>]+\s style\s*=\s* ["\'][^"\'>]+[:\s] url\(
 					|<style[^>]*>[^<]+ [:\s] url\()
-					(["\']?)(?![a-z]+:|[/\#])([^"\'>)\s]+)
+					(["\']?)(?![a-z]+:|[\#])([^"\'>)\s]+)
 					|\[\[ ([\w()+./@~-]+) \]\]
 				#ix',
 				captureOffset: true,
 			);
 			foreach (array_reverse($matches) as $m) {
-				$file = rtrim($basePath, '/\\') . '/' . (isset($m[4]) ? $m[4][0] : urldecode($m[3][0]));
+				$file = rtrim($basePath, '/\\') . '/' . ltrim(isset($m[4]) ? $m[4][0] : urldecode($m[3][0]), '/\\');
 				if (!isset($cids[$file])) {
 					$cids[$file] = substr($this->addEmbeddedFile($file)->getHeader('Content-ID'), 1, -1);
 				}

--- a/tests/Mail/Mail.textualAndHtmlBody.embedded.expect3
+++ b/tests/Mail/Mail.textualAndHtmlBody.embedded.expect3
@@ -1,0 +1,43 @@
+MIME-Version: 1.0
+X-Mailer: Nette Framework
+Date: %a%
+From: John Doe <doe@example.com>
+To: Lady Jane <jane@example.com>
+Subject: Hello Jane!
+Message-ID: <%S%@%S%>
+Content-Type: multipart/alternative;
+	boundary="--------%S%"
+
+----------%S%
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+Sample text
+----------%S%
+Content-Type: multipart/related;
+	boundary="--------%S%"
+
+----------%S%
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+	<BODY id=1 background="cid:%S%">
+	<img src="cid:%S%">
+	<div title=a style="background:url('cid:%S%')">
+	<style type=text/css>body { background: url('cid:%S%') } </style>
+	cid:%S%
+
+----------%S%
+Content-Type: image/png
+Content-Transfer-Encoding: base64
+Content-Disposition: inline; filename="background.png"
+Content-ID: <%S%>
+
+iVBORw0KGgoAAAANSUhEUgAABAAAAAAGCAMAAABq1Ry/AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ
+bWFnZVJlYWR5ccllPAAAADlQTFRFIYzeKYzeMZTeOZTeQpTeQpzeSpzeUpzeY6Xee73nhL3nlMbn
+nMbnrc7nvdbvxt7v1ufv5+fv7+/vqVk59gAAAKFJREFUeNrsmMEKgzAQRHcTq63WJPr/H9ska4vQ
+2rOG5+CEgT0JPiYrqiKiJue723Afp+ccQlqWFSHUtqQCQCoFVF0BwCMDYI4p8XUQal3269ubAeB7
+A0CI1gBWDMMattIA1BBQAdC9G0DcrgAfVuwPDMOaMHGqtgEo5o8bwDcKiETi1aP4QoDtyQWgtyXg
+bgdwzIDfxeBfYphhhk81/BJgAHfwneqeqMofAAAAAElFTkSuQmCC
+----------%S%--
+----------%S%--

--- a/tests/Mail/Mail.textualAndHtmlBody.embedded.phpt
+++ b/tests/Mail/Mail.textualAndHtmlBody.embedded.phpt
@@ -38,8 +38,6 @@ $mailer->send($mail);
 
 Assert::matchFile(__DIR__ . '/Mail.textualAndHtmlBody.embedded.expect', TestMailer::$output);
 
-
-
 $mail = new Message;
 $mail->setHTMLBody("
 	<a href='test.php?src=SOME'>some link</a>
@@ -53,3 +51,23 @@ $mailer = new TestMailer;
 $mailer->send($mail);
 
 Assert::matchFile(__DIR__ . '/Mail.textualAndHtmlBody.embedded2.expect', TestMailer::$output);
+
+$mail = new Message;
+
+$mail->setFrom('John Doe <doe@example.com>');
+$mail->addTo('Lady Jane <jane@example.com>');
+$mail->setSubject('Hello Jane!');
+
+$mail->setBody('Sample text');
+$mail->setHTMLBody('
+	<BODY id=1 background="/background.png">
+	<img src="/backgroun%64.png">
+	<div title=a style="background:url(\'/background.png\')">
+	<style type=text/css>body { background: url(\'/background.png\') } </style>
+	[[background.png]]
+', __DIR__ . '/fixtures');
+// append automatically $mail->addEmbeddedFile('files/background.png');
+
+$mailer = new TestMailer;
+$mailer->send($mail);
+Assert::matchFile(__DIR__ . '/Mail.textualAndHtmlBody.embedded.expect3', $mailer::$output);


### PR DESCRIPTION
- bug fix / new feature?  not sure
- BC break? yes

Currently, `setHTMLBody` in Nette\Mail supports a `basePath` for automatically embedding local images as CID attachments. Relative paths like `img/logo.svg` work correctly, but absolute paths starting with a slash (e.g. `/img/logo.svg`) are ignored and not embedded.

This PR updates the logic so that images referenced with a leading slash are correctly resolved relative to the provided `basePath`, allowing projects that use Webpack-generated assets (which always output to a fixed public folder with leading slashes) to work without breaking existing templates that rely on relative paths.

Here, basePath for mails is intended to represent the www folder of the application, making it clear that absolute paths are resolved relative to the web root.
